### PR TITLE
Refactor: Single-Role SFT Roles Registry

### DIFF
--- a/contracts/RolesRegistry.sol
+++ b/contracts/RolesRegistry.sol
@@ -2,9 +2,9 @@
 
 pragma solidity 0.8.9;
 
-import { IERC7432 } from "./interfaces/IERC7432.sol";
-import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import { IERC7432 } from './interfaces/IERC7432.sol';
+import { IERC721 } from '@openzeppelin/contracts/token/ERC721/IERC721.sol';
+import { ERC165Checker } from '@openzeppelin/contracts/utils/introspection/ERC165Checker.sol';
 
 contract RolesRegistry is IERC7432 {
     // grantee => tokenAddress => tokenId => role => struct(expirationDate, data)

--- a/contracts/RolesRegistry/SftRolesRegistry.sol
+++ b/contracts/RolesRegistry/SftRolesRegistry.sol
@@ -186,13 +186,13 @@ contract SftRolesRegistry is IERCXXXX, ERC1155Holder {
             _revokeRoleData.tokenAddress,
             _revokeRoleData.tokenId,
             tokensToReturn,
-            _revokeRoleData.revoker,
+            _revokeRoleData.grantor,
             _grantee
         );
 
         _transferFrom(
             address(this),
-            _revokeRoleData.revoker,
+            _revokeRoleData.grantor,
             _revokeRoleData.tokenAddress,
             _revokeRoleData.tokenId,
             tokensToReturn
@@ -271,7 +271,7 @@ contract SftRolesRegistry is IERCXXXX, ERC1155Holder {
                 _revokeRoleData.role,
                 _revokeRoleData.tokenAddress,
                 _revokeRoleData.tokenId,
-                _revokeRoleData.revoker
+                _revokeRoleData.grantor
             );
     }
 
@@ -287,10 +287,10 @@ contract SftRolesRegistry is IERCXXXX, ERC1155Holder {
 
     function _findCaller(RevokeRoleData calldata _revokeRoleData, address _grantee) internal view returns (address) {
         if (
-            _revokeRoleData.revoker == msg.sender ||
-            isRoleApprovedForAll(_revokeRoleData.tokenAddress, _revokeRoleData.revoker, msg.sender)
+            _revokeRoleData.grantor == msg.sender ||
+            isRoleApprovedForAll(_revokeRoleData.tokenAddress, _revokeRoleData.grantor, msg.sender)
         ) {
-            return _revokeRoleData.revoker;
+            return _revokeRoleData.grantor;
         }
 
         if (_grantee == msg.sender || isRoleApprovedForAll(_revokeRoleData.tokenAddress, _grantee, msg.sender)) {

--- a/contracts/RolesRegistry/SftRolesRegistrySingleRole.sol
+++ b/contracts/RolesRegistry/SftRolesRegistrySingleRole.sol
@@ -90,7 +90,9 @@ contract SftRolesRegistrySingleRole is ISftRolesRegistry, ERC1155Holder {
                 'SftRolesRegistry: tokenAmount mismatch'
             );
 
-            RoleData storage _roleData = roleAssignments[_grantRoleData.grantor][_grantRoleData.nonce][_grantRoleData.role];
+            RoleData storage _roleData = roleAssignments[_grantRoleData.grantor][_grantRoleData.nonce][
+                _grantRoleData.role
+            ];
             require(
                 _roleData.expirationDate < block.timestamp || _roleData.revocable,
                 'SftRolesRegistry: nonce is not expired or is not revocable'
@@ -129,12 +131,13 @@ contract SftRolesRegistrySingleRole is ISftRolesRegistry, ERC1155Holder {
     }
 
     function withdrawFrom(
-        address _grantor, uint256 _nonce
+        address _grantor,
+        uint256 _nonce
     ) public onlyOwnerOrApproved(_grantor, deposits[_grantor][_nonce].tokenAddress) {
-        require(deposits[_grantor][_nonce].tokenAmount != 0, "SftRolesRegistry: nonce does not exist");
+        require(deposits[_grantor][_nonce].tokenAmount != 0, 'SftRolesRegistry: nonce does not exist');
         require(
             roleAssignments[_grantor][_nonce][UNIQUE_ROLE].expirationDate < block.timestamp ||
-            roleAssignments[_grantor][_nonce][UNIQUE_ROLE].revocable,
+                roleAssignments[_grantor][_nonce][UNIQUE_ROLE].revocable,
             'SftRolesRegistry: token has an active role'
         );
 
@@ -250,5 +253,4 @@ contract SftRolesRegistrySingleRole is ISftRolesRegistry, ERC1155Holder {
         }
         revert('SftRolesRegistry: sender must be approved');
     }
-
 }

--- a/contracts/RolesRegistry/SftRolesRegistrySingleRole.sol
+++ b/contracts/RolesRegistry/SftRolesRegistrySingleRole.sol
@@ -14,13 +14,13 @@ contract SftRolesRegistrySingleRole is ISftRolesRegistry, ERC1155Holder {
     bytes32 public constant UNIQUE_ROLE = keccak256('UNIQUE_ROLE');
 
     // grantor => tokenAddress => operator => isApproved
-    mapping(address => mapping(address => mapping(address => bool))) public tokenApprovals;
+    mapping(address => mapping(address => mapping(address => bool))) public roleApprovals;
 
-    // nonce => DepositInfo
-    mapping(uint256 => DepositInfo) public deposits;
+    // grantor => nonce => DepositInfo
+    mapping(address => mapping(uint256 => DepositInfo)) public deposits;
 
-    // nonce => RoleAssignment
-    mapping(uint256 => RoleData) internal roleAssignments;
+    // grantor => nonce => role => RoleAssignment
+    mapping(address => mapping(uint256 => mapping(bytes32 => RoleData))) internal roleAssignments;
 
     modifier validGrantRoleData(
         uint256 _nonce,
@@ -46,12 +46,13 @@ contract SftRolesRegistrySingleRole is ISftRolesRegistry, ERC1155Holder {
     }
 
     modifier validRoleAndGrantee(
+        address _grantor,
         bytes32 _role,
         address _grantee,
         uint256 _nonce
     ) {
         require(_role == UNIQUE_ROLE, 'SftRolesRegistry: role not supported');
-        require(_grantee == roleAssignments[_nonce].grantee, 'SftRolesRegistry: grantee mismatch');
+        require(_grantee == roleAssignments[_grantor][_nonce][_role].grantee, 'SftRolesRegistry: grantee mismatch');
         _;
     }
 
@@ -71,29 +72,25 @@ contract SftRolesRegistrySingleRole is ISftRolesRegistry, ERC1155Holder {
         )
         onlyOwnerOrApproved(_grantRoleData.grantor, _grantRoleData.tokenAddress)
     {
-        if (deposits[_grantRoleData.nonce].grantor == address(0)) {
-            // transfer tokens
+        if (deposits[_grantRoleData.grantor][_grantRoleData.nonce].tokenAmount == 0) {
+            // nonce does not exist, transfer tokens
             _deposit(_grantRoleData);
         } else {
             // nonce exists
             require(
-                deposits[_grantRoleData.nonce].grantor == _grantRoleData.grantor,
-                'SftRolesRegistry: grantor mismatch'
-            );
-            require(
-                deposits[_grantRoleData.nonce].tokenAddress == _grantRoleData.tokenAddress,
+                deposits[_grantRoleData.grantor][_grantRoleData.nonce].tokenAddress == _grantRoleData.tokenAddress,
                 'SftRolesRegistry: tokenAddress mismatch'
             );
             require(
-                deposits[_grantRoleData.nonce].tokenId == _grantRoleData.tokenId,
+                deposits[_grantRoleData.grantor][_grantRoleData.nonce].tokenId == _grantRoleData.tokenId,
                 'SftRolesRegistry: tokenId mismatch'
             );
             require(
-                deposits[_grantRoleData.nonce].tokenAmount == _grantRoleData.tokenAmount,
+                deposits[_grantRoleData.grantor][_grantRoleData.nonce].tokenAmount == _grantRoleData.tokenAmount,
                 'SftRolesRegistry: tokenAmount mismatch'
             );
 
-            RoleData storage _roleData = roleAssignments[_grantRoleData.nonce];
+            RoleData storage _roleData = roleAssignments[_grantRoleData.grantor][_grantRoleData.nonce][_grantRoleData.role];
             require(
                 _roleData.expirationDate < block.timestamp || _roleData.revocable,
                 'SftRolesRegistry: nonce is not expired or is not revocable'
@@ -102,8 +99,118 @@ contract SftRolesRegistrySingleRole is ISftRolesRegistry, ERC1155Holder {
         _grantOrUpdateRole(_grantRoleData);
     }
 
+    function revokeRoleFrom(
+        address _grantor,
+        uint256 _nonce,
+        bytes32 _role,
+        address _grantee
+    ) external override validRoleAndGrantee(_grantor, _role, _grantee, _nonce) {
+        RoleData memory _roleData = roleAssignments[_grantor][_nonce][_role];
+        require(_roleData.expirationDate != 0, 'SftRolesRegistry: role does not exist');
+
+        DepositInfo memory _depositInfo = deposits[_grantor][_nonce];
+        address caller = _findCaller(_grantor, _roleData.grantee, _depositInfo.tokenAddress);
+        if (_roleData.expirationDate > block.timestamp && !_roleData.revocable) {
+            // if role is not expired and is not revocable, only the grantee can revoke it
+            require(caller == _roleData.grantee, 'SftRolesRegistry: nonce is not expired or is not revocable');
+        }
+
+        delete roleAssignments[_grantor][_nonce][_role];
+
+        emit RoleRevoked(
+            _grantor,
+            _nonce,
+            UNIQUE_ROLE,
+            _depositInfo.tokenAddress,
+            _depositInfo.tokenId,
+            _depositInfo.tokenAmount,
+            _roleData.grantee
+        );
+    }
+
+    function withdrawFrom(
+        address _grantor, uint256 _nonce
+    ) public onlyOwnerOrApproved(_grantor, deposits[_grantor][_nonce].tokenAddress) {
+        require(deposits[_grantor][_nonce].tokenAmount != 0, "SftRolesRegistry: nonce does not exist");
+        require(
+            roleAssignments[_grantor][_nonce][UNIQUE_ROLE].expirationDate < block.timestamp ||
+            roleAssignments[_grantor][_nonce][UNIQUE_ROLE].revocable,
+            'SftRolesRegistry: token has an active role'
+        );
+
+        delete roleAssignments[_grantor][_nonce][UNIQUE_ROLE];
+
+        _transferFrom(
+            address(this),
+            _grantor,
+            deposits[_grantor][_nonce].tokenAddress,
+            deposits[_grantor][_nonce].tokenId,
+            deposits[_grantor][_nonce].tokenAmount
+        );
+
+        delete deposits[_grantor][_nonce];
+        emit Withdrew(_grantor, _nonce);
+    }
+
+    function setRoleApprovalForAll(address _tokenAddress, address _operator, bool _isApproved) external override {
+        roleApprovals[msg.sender][_tokenAddress][_operator] = _isApproved;
+        emit RoleApprovalForAll(_tokenAddress, _operator, _isApproved);
+    }
+
+    /** View Functions **/
+
+    function roleData(
+        address _grantor,
+        uint256 _nonce,
+        bytes32 _role,
+        address _grantee
+    ) external view validRoleAndGrantee(_grantor, _role, _grantee, _nonce) returns (RoleData memory) {
+        return roleAssignments[_grantor][_nonce][_role];
+    }
+
+    function roleExpirationDate(
+        address _grantor,
+        uint256 _nonce,
+        bytes32 _role,
+        address _grantee
+    ) external view validRoleAndGrantee(_grantor, _role, _grantee, _nonce) returns (uint64 expirationDate_) {
+        return roleAssignments[_grantor][_nonce][_role].expirationDate;
+    }
+
+    function isRoleApprovedForAll(
+        address _tokenAddress,
+        address _grantor,
+        address _operator
+    ) public view override returns (bool) {
+        return roleApprovals[_grantor][_tokenAddress][_operator];
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC1155Receiver, IERC165) returns (bool) {
+        return interfaceId == type(ISftRolesRegistry).interfaceId || interfaceId == type(IERC1155Receiver).interfaceId;
+    }
+
+    /** Helper Functions **/
+
+    function _deposit(RoleAssignment calldata _grantRoleData) internal {
+        deposits[_grantRoleData.grantor][_grantRoleData.nonce] = DepositInfo(
+            _grantRoleData.tokenAddress,
+            _grantRoleData.tokenId,
+            _grantRoleData.tokenAmount
+        );
+
+        _transferFrom(
+            _grantRoleData.grantor,
+            address(this),
+            _grantRoleData.tokenAddress,
+            _grantRoleData.tokenId,
+            _grantRoleData.tokenAmount
+        );
+    }
+
     function _grantOrUpdateRole(RoleAssignment calldata _grantRoleData) internal {
-        roleAssignments[_grantRoleData.nonce] = RoleData(
+        roleAssignments[_grantRoleData.grantor][_grantRoleData.nonce][_grantRoleData.role] = RoleData(
             _grantRoleData.grantee,
             _grantRoleData.expirationDate,
             _grantRoleData.revocable,
@@ -124,100 +231,6 @@ contract SftRolesRegistrySingleRole is ISftRolesRegistry, ERC1155Holder {
         );
     }
 
-    function revokeRoleFrom(
-        address _grantor,
-        uint256 _nonce,
-        bytes32 _role,
-        address _grantee
-    ) external override validRoleAndGrantee(_role, _grantee, _nonce) {
-        RoleData memory _roleData = roleAssignments[_nonce];
-        DepositInfo memory _depositInfo = deposits[_nonce];
-
-        address caller = _findCaller(_roleData, _depositInfo);
-        if (_roleData.expirationDate > block.timestamp && !_roleData.revocable) {
-            // if role is not expired and is not revocable, only the grantee can revoke it
-            require(caller == _roleData.grantee, 'SftRolesRegistry: nonce is not expired or is not revocable');
-        }
-
-        delete roleAssignments[_nonce];
-
-        emit RoleRevoked(
-            _depositInfo.grantor,
-            _nonce,
-            UNIQUE_ROLE,
-            _depositInfo.tokenAddress,
-            _depositInfo.tokenId,
-            _depositInfo.tokenAmount,
-            _roleData.grantee
-        );
-    }
-
-    function withdrawFrom(
-        address _grantor, uint256 _nonce
-    ) public onlyOwnerOrApproved(deposits[_nonce].grantor, deposits[_nonce].tokenAddress) {
-        DepositInfo memory _depositInfo = deposits[_nonce];
-        require(
-            roleAssignments[_nonce].grantee == address(0) ||
-                roleAssignments[_nonce].expirationDate < block.timestamp ||
-                roleAssignments[_nonce].revocable,
-            'SftRolesRegistry: token has an active role'
-        );
-
-        delete deposits[_nonce];
-        delete roleAssignments[_nonce];
-
-        _transferFrom(
-            address(this),
-            _depositInfo.grantor,
-            _depositInfo.tokenAddress,
-            _depositInfo.tokenId,
-            _depositInfo.tokenAmount
-        );
-
-        emit Withdrew(_depositInfo.grantor, _nonce);
-    }
-
-    function setRoleApprovalForAll(address _tokenAddress, address _operator, bool _isApproved) external override {
-        tokenApprovals[msg.sender][_tokenAddress][_operator] = _isApproved;
-        emit RoleApprovalForAll(_tokenAddress, _operator, _isApproved);
-    }
-
-    /** View Functions **/
-
-    function roleData(
-        address _grantor,
-        uint256 _nonce,
-        bytes32 _role,
-        address _grantee
-    ) external view validRoleAndGrantee(_role, _grantee, _nonce) returns (RoleData memory) {
-        return roleAssignments[_nonce];
-    }
-
-    function roleExpirationDate(
-        address _grantor,
-        uint256 _nonce,
-        bytes32 _role,
-        address _grantee
-    ) external view validRoleAndGrantee(_role, _grantee, _nonce) returns (uint64 expirationDate_) {
-        return roleAssignments[_nonce].expirationDate;
-    }
-
-    function isRoleApprovedForAll(
-        address _tokenAddress,
-        address _grantor,
-        address _operator
-    ) public view override returns (bool) {
-        return tokenApprovals[_grantor][_tokenAddress][_operator];
-    }
-
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override(ERC1155Receiver, IERC165) returns (bool) {
-        return interfaceId == type(ISftRolesRegistry).interfaceId || interfaceId == type(IERC1155Receiver).interfaceId;
-    }
-
-    /** Helper Functions **/
-
     function _transferFrom(
         address _from,
         address _to,
@@ -228,38 +241,14 @@ contract SftRolesRegistrySingleRole is ISftRolesRegistry, ERC1155Holder {
         IERC1155(_tokenAddress).safeTransferFrom(_from, _to, _tokenId, _tokenAmount, '');
     }
 
-    function _findCaller(RoleData memory _roleData, DepositInfo memory _depositInfo) internal view returns (address) {
-        if (
-            _depositInfo.grantor == msg.sender ||
-            isRoleApprovedForAll(_depositInfo.tokenAddress, _depositInfo.grantor, msg.sender)
-        ) {
-            return _depositInfo.grantor;
+    function _findCaller(address _grantor, address _grantee, address _tokenAddress) internal view returns (address) {
+        if (_grantor == msg.sender || isRoleApprovedForAll(_tokenAddress, _grantor, msg.sender)) {
+            return _grantor;
         }
-
-        if (
-            _roleData.grantee == msg.sender ||
-            isRoleApprovedForAll(_depositInfo.tokenAddress, _roleData.grantee, msg.sender)
-        ) {
-            return _roleData.grantee;
+        if (_grantee == msg.sender || isRoleApprovedForAll(_tokenAddress, _grantee, msg.sender)) {
+            return _grantee;
         }
-
         revert('SftRolesRegistry: sender must be approved');
     }
 
-    function _deposit(RoleAssignment calldata _grantRoleData) internal {
-        deposits[_grantRoleData.nonce] = DepositInfo(
-            _grantRoleData.grantor,
-            _grantRoleData.tokenAddress,
-            _grantRoleData.tokenId,
-            _grantRoleData.tokenAmount
-        );
-
-        _transferFrom(
-            _grantRoleData.grantor,
-            address(this),
-            _grantRoleData.tokenAddress,
-            _grantRoleData.tokenId,
-            _grantRoleData.tokenAmount
-        );
-    }
 }

--- a/contracts/RolesRegistry/SftRolesRegistrySingleRole.sol
+++ b/contracts/RolesRegistry/SftRolesRegistrySingleRole.sol
@@ -52,7 +52,10 @@ contract SftRolesRegistrySingleRole is ISftRolesRegistry, ERC1155Holder {
         uint256 _nonce
     ) {
         require(_role == UNIQUE_ROLE, 'SftRolesRegistry: role not supported');
-        require(_grantee == roleAssignments[_grantor][_nonce][_role].grantee, 'SftRolesRegistry: grantee mismatch');
+        require(
+            _grantee != address(0) && _grantee == roleAssignments[_grantor][_nonce][_role].grantee,
+            'SftRolesRegistry: grantee mismatch'
+        );
         _;
     }
 
@@ -106,11 +109,12 @@ contract SftRolesRegistrySingleRole is ISftRolesRegistry, ERC1155Holder {
         uint256 _nonce,
         bytes32 _role,
         address _grantee
-    ) external override validRoleAndGrantee(_grantor, _role, _grantee, _nonce) {
+    ) external override {
         RoleData memory _roleData = roleAssignments[_grantor][_nonce][_role];
         require(_roleData.expirationDate != 0, 'SftRolesRegistry: role does not exist');
+        require(_grantee == _roleData.grantee, 'SftRolesRegistry: grantee mismatch');
 
-        DepositInfo memory _depositInfo = deposits[_grantor][_nonce];
+        DepositInfo storage _depositInfo = deposits[_grantor][_nonce];
         address caller = _findCaller(_grantor, _roleData.grantee, _depositInfo.tokenAddress);
         if (_roleData.expirationDate > block.timestamp && !_roleData.revocable) {
             // if role is not expired and is not revocable, only the grantee can revoke it

--- a/contracts/RolesRegistry/SftRolesRegistrySingleRole.sol
+++ b/contracts/RolesRegistry/SftRolesRegistrySingleRole.sol
@@ -111,12 +111,12 @@ contract SftRolesRegistrySingleRole is ISftRolesRegistry, ERC1155Holder {
         );
 
         emit RoleGranted(
+            _grantRoleData.grantor,
             _grantRoleData.nonce,
             UNIQUE_ROLE,
             _grantRoleData.tokenAddress,
             _grantRoleData.tokenId,
             _grantRoleData.tokenAmount,
-            _grantRoleData.grantor,
             _grantRoleData.grantee,
             _grantRoleData.expirationDate,
             _grantRoleData.revocable,
@@ -125,6 +125,7 @@ contract SftRolesRegistrySingleRole is ISftRolesRegistry, ERC1155Holder {
     }
 
     function revokeRoleFrom(
+        address _grantor,
         uint256 _nonce,
         bytes32 _role,
         address _grantee
@@ -141,18 +142,18 @@ contract SftRolesRegistrySingleRole is ISftRolesRegistry, ERC1155Holder {
         delete roleAssignments[_nonce];
 
         emit RoleRevoked(
+            _depositInfo.grantor,
             _nonce,
             UNIQUE_ROLE,
             _depositInfo.tokenAddress,
             _depositInfo.tokenId,
             _depositInfo.tokenAmount,
-            _depositInfo.grantor,
             _roleData.grantee
         );
     }
 
-    function withdraw(
-        uint256 _nonce
+    function withdrawFrom(
+        address _grantor, uint256 _nonce
     ) public onlyOwnerOrApproved(deposits[_nonce].grantor, deposits[_nonce].tokenAddress) {
         DepositInfo memory _depositInfo = deposits[_nonce];
         require(
@@ -173,13 +174,7 @@ contract SftRolesRegistrySingleRole is ISftRolesRegistry, ERC1155Holder {
             _depositInfo.tokenAmount
         );
 
-        emit Withdrew(
-            _nonce,
-            _depositInfo.grantor,
-            _depositInfo.tokenAddress,
-            _depositInfo.tokenId,
-            _depositInfo.tokenAmount
-        );
+        emit Withdrew(_depositInfo.grantor, _nonce);
     }
 
     function setRoleApprovalForAll(address _tokenAddress, address _operator, bool _isApproved) external override {
@@ -190,6 +185,7 @@ contract SftRolesRegistrySingleRole is ISftRolesRegistry, ERC1155Holder {
     /** View Functions **/
 
     function roleData(
+        address _grantor,
         uint256 _nonce,
         bytes32 _role,
         address _grantee
@@ -198,6 +194,7 @@ contract SftRolesRegistrySingleRole is ISftRolesRegistry, ERC1155Holder {
     }
 
     function roleExpirationDate(
+        address _grantor,
         uint256 _nonce,
         bytes32 _role,
         address _grantee

--- a/contracts/RolesRegistry/interfaces/IERCXXXX.sol
+++ b/contracts/RolesRegistry/interfaces/IERCXXXX.sol
@@ -101,7 +101,13 @@ interface IERCXXXX is IERC165 {
     /// @param _tokenAddress The token address.
     /// @param _tokenId The token identifier.
     /// @param _tokenAmount The token amount withdrawn.
-    event Withdrew(uint256 indexed _nonce, address indexed _grantor, address _tokenAddress, uint256 _tokenId, uint256 _tokenAmount);
+    event Withdrew(
+        uint256 indexed _nonce,
+        address indexed _grantor,
+        address _tokenAddress,
+        uint256 _tokenId,
+        uint256 _tokenAmount
+    );
 
     /** External Functions **/
 

--- a/contracts/RolesRegistry/interfaces/IERCXXXX.sol
+++ b/contracts/RolesRegistry/interfaces/IERCXXXX.sol
@@ -42,7 +42,7 @@ interface IERCXXXX is IERC165 {
         bytes32 role;
         address tokenAddress;
         uint256 tokenId;
-        address revoker;
+        address grantor;
     }
 
     /** Events **/
@@ -77,7 +77,7 @@ interface IERCXXXX is IERC165 {
     /// @param _tokenAddress The token address.
     /// @param _tokenId The token identifier.
     /// @param _tokenAmount The token amount.
-    /// @param _revoker The user revoking the role.
+    /// @param _grantor The user revoking the role.
     /// @param _grantee The user that receives the role revocation.
     event RoleRevoked(
         uint256 indexed _nonce,
@@ -85,7 +85,7 @@ interface IERCXXXX is IERC165 {
         address _tokenAddress,
         uint256 _tokenId,
         uint256 _tokenAmount,
-        address _revoker,
+        address _grantor,
         address _grantee
     );
 

--- a/contracts/RolesRegistry/interfaces/ISftRolesRegistry.sol
+++ b/contracts/RolesRegistry/interfaces/ISftRolesRegistry.sol
@@ -16,7 +16,6 @@ interface ISftRolesRegistry is IERC165 {
     }
 
     struct DepositInfo {
-        address grantor; // todo do we need this?
         address tokenAddress;
         uint256 tokenId;
         uint256 tokenAmount;

--- a/contracts/RolesRegistry/interfaces/ISftRolesRegistry.sol
+++ b/contracts/RolesRegistry/interfaces/ISftRolesRegistry.sol
@@ -6,7 +6,7 @@ import { IERC165 } from '@openzeppelin/contracts/utils/introspection/IERC165.sol
 
 /// @title ERC-XXXX Semi-Fungible Token Roles
 /// @dev See https://eips.ethereum.org/EIPS/eip-XXXX
-/// Note: the ERC-165 identifier for this interface is 0x91bb3904
+/// Note: the ERC-165 identifier for this interface is 0xd38a803e
 interface ISftRolesRegistry is IERC165 {
     struct RoleData {
         address grantee;

--- a/contracts/RolesRegistry/interfaces/ISftRolesRegistry.sol
+++ b/contracts/RolesRegistry/interfaces/ISftRolesRegistry.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.8.9;
 
-import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import { IERC165 } from '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 
 /// @title ERC-XXXX Semi-Fungible Token Roles
 /// @dev See https://eips.ethereum.org/EIPS/eip-XXXX

--- a/contracts/interfaces/IImmutableOwnerCreate2Factory.sol
+++ b/contracts/interfaces/IImmutableOwnerCreate2Factory.sol
@@ -2,13 +2,7 @@
 pragma solidity 0.8.9;
 
 interface IImmutableOwnerCreate2Factory {
-    function deploy(
-        bytes32 salt,
-        bytes memory bytecode
-    ) external returns (address addr);
+    function deploy(bytes32 salt, bytes memory bytecode) external returns (address addr);
 
-    function computeAddress(
-        bytes32 salt,
-        bytes32 bytecodeHash
-    ) external view returns (address);
+    function computeAddress(bytes32 salt, bytes32 bytecodeHash) external view returns (address);
 }

--- a/contracts/test/StfRolesRegistryTest.sol
+++ b/contracts/test/StfRolesRegistryTest.sol
@@ -60,7 +60,7 @@ contract SftRolesRegistryTest is SetupTest {
             role: role,
             tokenAddress: address(mockERC1155),
             tokenId: tokenId,
-            revoker: msg.sender
+            grantor: msg.sender
         });
 
         vm.startPrank(grantee);

--- a/test/SftRolesRegistry/SftRolesRegistry.spec.ts
+++ b/test/SftRolesRegistry/SftRolesRegistry.spec.ts
@@ -539,7 +539,7 @@ describe('SftRolesRegistry', async () => {
       await expect(
         SftRolesRegistry.connect(grantor).revokeRoleFrom({
           ...RevokeRoleData,
-          revoker: anotherUser.address,
+          grantor: anotherUser.address,
         }),
       ).to.be.revertedWith('SftRolesRegistry: could not find role assignment')
     })
@@ -579,7 +579,7 @@ describe('SftRolesRegistry', async () => {
           newRevokeRoleData.tokenAddress,
           newRevokeRoleData.tokenId,
           newRoleAssignment.tokenAmount,
-          newRevokeRoleData.revoker,
+          newRevokeRoleData.grantor,
           newRoleAssignment.grantee,
         )
     })
@@ -599,7 +599,7 @@ describe('SftRolesRegistry', async () => {
           RevokeRoleData.tokenAddress,
           RevokeRoleData.tokenId,
           RoleAssignment.tokenAmount,
-          RevokeRoleData.revoker,
+          RevokeRoleData.grantor,
           RevokeRoleData.grantee,
         )
         // transfer tokens back to owner
@@ -607,7 +607,7 @@ describe('SftRolesRegistry', async () => {
         .withArgs(
           SftRolesRegistry.address,
           SftRolesRegistry.address,
-          RevokeRoleData.revoker,
+          RevokeRoleData.grantor,
           RevokeRoleData.tokenId,
           RoleAssignment.tokenAmount,
         )
@@ -627,7 +627,7 @@ describe('SftRolesRegistry', async () => {
           RevokeRoleData.tokenAddress,
           RevokeRoleData.tokenId,
           RoleAssignment.tokenAmount,
-          RevokeRoleData.revoker,
+          RevokeRoleData.grantor,
           RevokeRoleData.grantee,
         )
         // transfer tokens back to owner
@@ -635,7 +635,7 @@ describe('SftRolesRegistry', async () => {
         .withArgs(
           SftRolesRegistry.address,
           SftRolesRegistry.address,
-          RevokeRoleData.revoker,
+          RevokeRoleData.grantor,
           RevokeRoleData.tokenId,
           RoleAssignment.tokenAmount,
         )
@@ -654,7 +654,7 @@ describe('SftRolesRegistry', async () => {
           RevokeRoleData.tokenAddress,
           RevokeRoleData.tokenId,
           RoleAssignment.tokenAmount,
-          RevokeRoleData.revoker,
+          RevokeRoleData.grantor,
           RevokeRoleData.grantee,
         )
         // transfer tokens back to owner
@@ -662,7 +662,7 @@ describe('SftRolesRegistry', async () => {
         .withArgs(
           SftRolesRegistry.address,
           SftRolesRegistry.address,
-          RevokeRoleData.revoker,
+          RevokeRoleData.grantor,
           RevokeRoleData.tokenId,
           RoleAssignment.tokenAmount,
         )
@@ -677,7 +677,7 @@ describe('SftRolesRegistry', async () => {
           RevokeRoleData.tokenAddress,
           RevokeRoleData.tokenId,
           RoleAssignment.tokenAmount,
-          RevokeRoleData.revoker,
+          RevokeRoleData.grantor,
           RoleAssignment.grantee,
         )
         // transfer tokens back to owner
@@ -685,7 +685,7 @@ describe('SftRolesRegistry', async () => {
         .withArgs(
           SftRolesRegistry.address,
           SftRolesRegistry.address,
-          RevokeRoleData.revoker,
+          RevokeRoleData.grantor,
           RevokeRoleData.tokenId,
           RoleAssignment.tokenAmount,
         )

--- a/test/SftRolesRegistry/SftRolesRegistry.spec.ts
+++ b/test/SftRolesRegistry/SftRolesRegistry.spec.ts
@@ -773,7 +773,7 @@ describe('SftRolesRegistry', async () => {
     })
   })
 
-  describe('RoleBalanceOf', async () => {
+  describe('RoleBalanceOf @skip-on-coverage', async () => {
     it('should check at least 4300 grant roles without run out of gas', async function () {
       const tokenId = generateRandomInt()
       const role = generateRoleId('Role()')
@@ -803,14 +803,14 @@ describe('SftRolesRegistry', async () => {
 
       await MockToken.mint(grantor.address, tokenId, totalAmount * 2)
 
-      const promises = roleAssignments.map((t, i) => SftRolesRegistry.connect(grantor).grantRoleFrom(t))
+      const promises = roleAssignments.map(t => SftRolesRegistry.connect(grantor).grantRoleFrom(t))
       await Promise.all(promises)
 
       expect(await SftRolesRegistry.roleBalanceOf(role, MockToken.address, tokenId, grantee.address)).to.be.equal(
         totalAmount,
       )
 
-      const revokePromises = roleAssignments.map(async (t, i) => {
+      const revokePromises = roleAssignments.map(async t => {
         const revokeRoleData = buildRevokeRoleData(t)
         return SftRolesRegistry.connect(grantee).revokeRoleFrom(revokeRoleData)
       })
@@ -827,7 +827,6 @@ describe('SftRolesRegistry', async () => {
     })
 
     it('should return true if SftRolesRegistry interface id (0x89cb6ab6)', async () => {
-      //const id = getInterfaceID(IERCXXXX__factory.createInterface())
       expect(await SftRolesRegistry.supportsInterface('0x89cb6ab6')).to.be.true
     })
   })

--- a/test/SftRolesRegistry/SftRolesRegistrySingleRole.spec.ts
+++ b/test/SftRolesRegistry/SftRolesRegistrySingleRole.spec.ts
@@ -317,7 +317,12 @@ describe('SftRolesRegistrySingleRole', async () => {
       await expect(SftRolesRegistry.connect(grantor).grantRoleFrom(newRoleAssignment))
 
       await expect(
-        SftRolesRegistry.connect(grantor).revokeRoleFrom(newRevokeRoleData.grantor, newRevokeRoleData.nonce, newRevokeRoleData.role, AddressZero),
+        SftRolesRegistry.connect(grantor).revokeRoleFrom(
+          newRevokeRoleData.grantor,
+          newRevokeRoleData.nonce,
+          newRevokeRoleData.role,
+          AddressZero,
+        ),
       ).to.be.revertedWith('SftRolesRegistry: grantee mismatch')
     })
 
@@ -511,13 +516,15 @@ describe('SftRolesRegistrySingleRole', async () => {
     })
 
     it('should revert when nonce has a role is not expired', async () => {
-      await expect(SftRolesRegistry.connect(grantor).withdrawFrom(RoleAssignment.grantor, RoleAssignment.nonce))
-        .to.be.revertedWith('SftRolesRegistry: token has an active role')
+      await expect(
+        SftRolesRegistry.connect(grantor).withdrawFrom(RoleAssignment.grantor, RoleAssignment.nonce),
+      ).to.be.revertedWith('SftRolesRegistry: token has an active role')
     })
 
     it('should revert if nonce does not exist', async () => {
-      await expect(SftRolesRegistry.connect(grantor).withdrawFrom(RevokeRoleData.grantor, generateRandomInt()))
-        .to.be.revertedWith('SftRolesRegistry: nonce does not exist')
+      await expect(
+        SftRolesRegistry.connect(grantor).withdrawFrom(RevokeRoleData.grantor, generateRandomInt()),
+      ).to.be.revertedWith('SftRolesRegistry: nonce does not exist')
     })
 
     it('should not revert if nonce is expired', async () => {
@@ -567,7 +574,6 @@ describe('SftRolesRegistrySingleRole', async () => {
     })
 
     describe('RoleData', async () => {
-
       it('should return the role data', async () => {
         const roleData = await SftRolesRegistry.roleData(
           RoleAssignment.grantor,
@@ -583,7 +589,12 @@ describe('SftRolesRegistrySingleRole', async () => {
 
       it('should revert if role is not UNIQUE_ROLE', async () => {
         await expect(
-          SftRolesRegistry.roleData(RoleAssignment.grantor, RoleAssignment.nonce, generateRoleId('NOT_UNIQUE_ROLE'), RoleAssignment.grantee),
+          SftRolesRegistry.roleData(
+            RoleAssignment.grantor,
+            RoleAssignment.nonce,
+            generateRoleId('NOT_UNIQUE_ROLE'),
+            RoleAssignment.grantee,
+          ),
         ).to.be.revertedWith('SftRolesRegistry: role not supported')
       })
 
@@ -592,19 +603,17 @@ describe('SftRolesRegistrySingleRole', async () => {
           SftRolesRegistry.roleData(RoleAssignment.grantor, RoleAssignment.nonce, RoleAssignment.role, AddressZero),
         ).to.be.revertedWith('SftRolesRegistry: grantee mismatch')
       })
-
     })
 
     describe('RoleExpirationDate', async () => {
-
       it('should return the expiration date', async () => {
         expect(
           await SftRolesRegistry.roleExpirationDate(
             RoleAssignment.grantor,
             RoleAssignment.nonce,
             RoleAssignment.role,
-            RoleAssignment.grantee
-          )
+            RoleAssignment.grantee,
+          ),
         ).to.be.equal(RoleAssignment.expirationDate)
       })
 
@@ -621,10 +630,14 @@ describe('SftRolesRegistrySingleRole', async () => {
 
       it('should revert if grantee is invalid', async () => {
         await expect(
-          SftRolesRegistry.roleExpirationDate(RoleAssignment.grantor, RoleAssignment.nonce, RoleAssignment.role, AddressZero),
+          SftRolesRegistry.roleExpirationDate(
+            RoleAssignment.grantor,
+            RoleAssignment.nonce,
+            RoleAssignment.role,
+            AddressZero,
+          ),
         ).to.be.revertedWith('SftRolesRegistry: grantee mismatch')
       })
-
     })
   })
 

--- a/test/SftRolesRegistry/SftRolesRegistrySingleRole.spec.ts
+++ b/test/SftRolesRegistry/SftRolesRegistrySingleRole.spec.ts
@@ -145,12 +145,12 @@ describe('SftRolesRegistrySingleRole', async () => {
         await expect(SftRolesRegistry.connect(grantor).grantRoleFrom(roleAssignment))
           .to.emit(SftRolesRegistry, 'RoleGranted')
           .withArgs(
+            roleAssignment.grantor,
             roleAssignment.nonce,
             roleAssignment.role,
             roleAssignment.tokenAddress,
             roleAssignment.tokenId,
             roleAssignment.tokenAmount,
-            roleAssignment.grantor,
             roleAssignment.grantee,
             roleAssignment.expirationDate,
             roleAssignment.revocable,
@@ -174,18 +174,19 @@ describe('SftRolesRegistrySingleRole', async () => {
         await expect(SftRolesRegistry.connect(anotherUser).grantRoleFrom(roleAssignment))
           .to.emit(SftRolesRegistry, 'RoleGranted')
           .withArgs(
+            roleAssignment.grantor,
             roleAssignment.nonce,
             roleAssignment.role,
             roleAssignment.tokenAddress,
             roleAssignment.tokenId,
             roleAssignment.tokenAmount,
-            roleAssignment.grantor,
             roleAssignment.grantee,
             roleAssignment.expirationDate,
             roleAssignment.revocable,
             roleAssignment.data,
           )
       })
+
       it('should revert if grantor tries to update a grant with a nonce that its not theirs', async function () {
         const roleAssignment = await buildRoleAssignment({
           tokenAddress: MockToken.address,
@@ -202,12 +203,12 @@ describe('SftRolesRegistrySingleRole', async () => {
         await expect(SftRolesRegistry.connect(anotherUser).grantRoleFrom(roleAssignment))
           .to.emit(SftRolesRegistry, 'RoleGranted')
           .withArgs(
+            roleAssignment.grantor,
             roleAssignment.nonce,
             roleAssignment.role,
             roleAssignment.tokenAddress,
             roleAssignment.tokenId,
             roleAssignment.tokenAmount,
-            roleAssignment.grantor,
             roleAssignment.grantee,
             roleAssignment.expirationDate,
             roleAssignment.revocable,
@@ -236,12 +237,12 @@ describe('SftRolesRegistrySingleRole', async () => {
       await expect(SftRolesRegistry.connect(grantor).grantRoleFrom(RoleAssignment))
         .to.emit(SftRolesRegistry, 'RoleGranted')
         .withArgs(
+          RoleAssignment.grantor,
           RoleAssignment.nonce,
           RoleAssignment.role,
           RoleAssignment.tokenAddress,
           RoleAssignment.tokenId,
           RoleAssignment.tokenAmount,
-          RoleAssignment.grantor,
           RoleAssignment.grantee,
           RoleAssignment.expirationDate,
           RoleAssignment.revocable,
@@ -303,12 +304,12 @@ describe('SftRolesRegistrySingleRole', async () => {
       await expect(SftRolesRegistry.connect(grantor).grantRoleFrom(RoleAssignment))
         .to.emit(SftRolesRegistry, 'RoleGranted')
         .withArgs(
+          RoleAssignment.grantor,
           RoleAssignment.nonce,
           RoleAssignment.role,
           RoleAssignment.tokenAddress,
           RoleAssignment.tokenId,
           RoleAssignment.tokenAmount,
-          RoleAssignment.grantor,
           RoleAssignment.grantee,
           RoleAssignment.expirationDate,
           RoleAssignment.revocable,
@@ -350,7 +351,7 @@ describe('SftRolesRegistrySingleRole', async () => {
       await expect(SftRolesRegistry.connect(grantor).grantRoleFrom(newRoleAssignment))
 
       await expect(
-        SftRolesRegistry.connect(grantor).revokeRoleFrom(newRevokeRoleData.nonce, newRevokeRoleData.role, AddressZero),
+        SftRolesRegistry.connect(grantor).revokeRoleFrom(newRevokeRoleData.grantor, newRevokeRoleData.nonce, newRevokeRoleData.role, AddressZero),
       ).to.be.revertedWith('SftRolesRegistry: grantee mismatch')
     })
 
@@ -369,6 +370,7 @@ describe('SftRolesRegistrySingleRole', async () => {
 
       await expect(
         SftRolesRegistry.connect(grantor).revokeRoleFrom(
+          newRevokeRoleData.grantor,
           newRevokeRoleData.nonce,
           newRevokeRoleData.role,
           newRevokeRoleData.grantee,
@@ -379,6 +381,7 @@ describe('SftRolesRegistrySingleRole', async () => {
     it('should revert if caller is not approved', async () => {
       await expect(
         SftRolesRegistry.connect(anotherUser).revokeRoleFrom(
+          RevokeRoleData.grantor,
           RevokeRoleData.nonce,
           RevokeRoleData.role,
           RevokeRoleData.grantee,
@@ -389,6 +392,7 @@ describe('SftRolesRegistrySingleRole', async () => {
     it('should revoke role if sender is revoker', async () => {
       await expect(
         SftRolesRegistry.connect(grantor).revokeRoleFrom(
+          RevokeRoleData.grantor,
           RevokeRoleData.nonce,
           RevokeRoleData.role,
           RevokeRoleData.grantee,
@@ -396,12 +400,12 @@ describe('SftRolesRegistrySingleRole', async () => {
       )
         .to.emit(SftRolesRegistry, 'RoleRevoked')
         .withArgs(
+          RevokeRoleData.grantor,
           RevokeRoleData.nonce,
           RevokeRoleData.role,
           RevokeRoleData.tokenAddress,
           RevokeRoleData.tokenId,
           RoleAssignment.tokenAmount,
-          RevokeRoleData.revoker,
           RevokeRoleData.grantee,
         )
     })
@@ -418,6 +422,7 @@ describe('SftRolesRegistrySingleRole', async () => {
 
       await expect(
         SftRolesRegistry.connect(grantor).revokeRoleFrom(
+          RevokeRoleData.grantor,
           newRoleAssignment.nonce,
           newRoleAssignment.role,
           newRoleAssignment.grantee,
@@ -433,6 +438,7 @@ describe('SftRolesRegistrySingleRole', async () => {
       )
       await expect(
         SftRolesRegistry.connect(anotherUser).revokeRoleFrom(
+          RevokeRoleData.grantor,
           RevokeRoleData.nonce,
           RevokeRoleData.role,
           RevokeRoleData.grantee,
@@ -440,12 +446,12 @@ describe('SftRolesRegistrySingleRole', async () => {
       )
         .to.emit(SftRolesRegistry, 'RoleRevoked')
         .withArgs(
+          RevokeRoleData.grantor,
           RevokeRoleData.nonce,
           RevokeRoleData.role,
           RevokeRoleData.tokenAddress,
           RevokeRoleData.tokenId,
           RoleAssignment.tokenAmount,
-          RevokeRoleData.revoker,
           RevokeRoleData.grantee,
         )
     })
@@ -457,6 +463,7 @@ describe('SftRolesRegistrySingleRole', async () => {
       )
       await expect(
         SftRolesRegistry.connect(anotherUser).revokeRoleFrom(
+          RevokeRoleData.grantor,
           RevokeRoleData.nonce,
           RevokeRoleData.role,
           RevokeRoleData.grantee,
@@ -464,12 +471,12 @@ describe('SftRolesRegistrySingleRole', async () => {
       )
         .to.emit(SftRolesRegistry, 'RoleRevoked')
         .withArgs(
+          RevokeRoleData.grantor,
           RevokeRoleData.nonce,
           RevokeRoleData.role,
           RevokeRoleData.tokenAddress,
           RevokeRoleData.tokenId,
           RoleAssignment.tokenAmount,
-          RevokeRoleData.revoker,
           RevokeRoleData.grantee,
         )
     })
@@ -490,6 +497,7 @@ describe('SftRolesRegistrySingleRole', async () => {
 
       await expect(
         SftRolesRegistry.connect(grantee).revokeRoleFrom(
+          RevokeRoleData.grantor,
           newRevokeRoleData.nonce,
           newRevokeRoleData.role,
           RevokeRoleData.grantee,
@@ -497,12 +505,12 @@ describe('SftRolesRegistrySingleRole', async () => {
       )
         .to.emit(SftRolesRegistry, 'RoleRevoked')
         .withArgs(
+          newRevokeRoleData.grantor,
           newRevokeRoleData.nonce,
           newRevokeRoleData.role,
           newRevokeRoleData.tokenAddress,
           newRevokeRoleData.tokenId,
           newRoleAssignment.tokenAmount,
-          newRevokeRoleData.revoker,
           newRevokeRoleData.grantee,
         )
     })
@@ -537,46 +545,35 @@ describe('SftRolesRegistrySingleRole', async () => {
     })
 
     it('should revert nonce role is not expired', async () => {
-      await expect(SftRolesRegistry.connect(grantor).withdraw(RevokeRoleData.nonce)).to.be.revertedWith(
+      await expect(SftRolesRegistry.connect(grantor).withdrawFrom(RevokeRoleData.grantor, RevokeRoleData.nonce)).to.be.revertedWith(
         'SftRolesRegistry: token has an active role',
       )
     })
 
     it('should revert if nonce does not exist', async () => {
-      await expect(SftRolesRegistry.connect(grantor).withdraw(generateRandomInt())).to.be.revertedWith(
+      await expect(SftRolesRegistry.connect(grantor).withdrawFrom(RevokeRoleData.grantor, generateRandomInt())).to.be.revertedWith(
         'SftRolesRegistry: account not approved',
       )
     })
 
     it('should not revert if nonce is expired', async () => {
       await time.increase(ONE_DAY)
-      await expect(SftRolesRegistry.connect(grantor).withdraw(RevokeRoleData.nonce))
+      await expect(SftRolesRegistry.connect(grantor).withdrawFrom(RevokeRoleData.grantor, RevokeRoleData.nonce))
         .to.emit(SftRolesRegistry, 'Withdrew')
-        .withArgs(
-          RevokeRoleData.nonce,
-          RevokeRoleData.revoker,
-          RevokeRoleData.tokenAddress,
-          RevokeRoleData.tokenId,
-          RoleAssignment.tokenAmount,
-        )
+        .withArgs(RevokeRoleData.grantor, RevokeRoleData.nonce)
     })
 
     it('should not revert if nonce has a role revoked', async () => {
       await time.increase(ONE_DAY)
       await SftRolesRegistry.connect(grantor).revokeRoleFrom(
+        RevokeRoleData.grantor,
         RevokeRoleData.nonce,
         RevokeRoleData.role,
         RevokeRoleData.grantee,
       )
-      await expect(SftRolesRegistry.connect(grantor).withdraw(RevokeRoleData.nonce))
+      await expect(SftRolesRegistry.connect(grantor).withdrawFrom(RevokeRoleData.grantor, RevokeRoleData.nonce))
         .to.emit(SftRolesRegistry, 'Withdrew')
-        .withArgs(
-          RevokeRoleData.nonce,
-          RevokeRoleData.revoker,
-          RevokeRoleData.tokenAddress,
-          RevokeRoleData.tokenId,
-          RoleAssignment.tokenAmount,
-        )
+        .withArgs(RoleAssignment.grantor, RoleAssignment.nonce)
     })
 
     it('shoudl not revert if nonce has a revocable role', async () => {
@@ -584,15 +581,9 @@ describe('SftRolesRegistrySingleRole', async () => {
       RoleAssignment.revocable = true
       RoleAssignment.expirationDate = (await time.latest()) + ONE_DAY
       await SftRolesRegistry.connect(grantor).grantRoleFrom(RoleAssignment)
-      await expect(SftRolesRegistry.connect(grantor).withdraw(RevokeRoleData.nonce))
+      await expect(SftRolesRegistry.connect(grantor).withdrawFrom(RevokeRoleData.grantor, RevokeRoleData.nonce))
         .to.emit(SftRolesRegistry, 'Withdrew')
-        .withArgs(
-          RevokeRoleData.nonce,
-          RevokeRoleData.revoker,
-          RevokeRoleData.tokenAddress,
-          RevokeRoleData.tokenId,
-          RoleAssignment.tokenAmount,
-        )
+        .withArgs(RevokeRoleData.grantor, RevokeRoleData.nonce)
     })
   })
 
@@ -612,8 +603,10 @@ describe('SftRolesRegistrySingleRole', async () => {
     })
 
     describe('RoleData', async () => {
+
       it('should return the role data', async () => {
         const roleData = await SftRolesRegistry.roleData(
+          RoleAssignment.grantor,
           RoleAssignment.nonce,
           RoleAssignment.role,
           RoleAssignment.grantee,
@@ -623,38 +616,51 @@ describe('SftRolesRegistrySingleRole', async () => {
         expect(roleData.revocable).to.be.equal(RoleAssignment.revocable)
         expect(roleData.data).to.be.equal(RoleAssignment.data)
       })
+
       it('should revert if role is not UNIQUE_ROLE', async () => {
         await expect(
-          SftRolesRegistry.roleData(RoleAssignment.nonce, generateRoleId('NOT_UNIQUE_ROLE'), RoleAssignment.grantee),
+          SftRolesRegistry.roleData(RoleAssignment.grantor, RoleAssignment.nonce, generateRoleId('NOT_UNIQUE_ROLE'), RoleAssignment.grantee),
         ).to.be.revertedWith('SftRolesRegistry: role not supported')
       })
+
       it('should revert if grantee is invalid', async () => {
         await expect(
-          SftRolesRegistry.roleData(RoleAssignment.nonce, RoleAssignment.role, AddressZero),
+          SftRolesRegistry.roleData(RoleAssignment.grantor, RoleAssignment.nonce, RoleAssignment.role, AddressZero),
         ).to.be.revertedWith('SftRolesRegistry: grantee mismatch')
       })
+
     })
 
     describe('RoleExpirationDate', async () => {
+
       it('should return the expiration date', async () => {
         expect(
-          await SftRolesRegistry.roleExpirationDate(RoleAssignment.nonce, RoleAssignment.role, RoleAssignment.grantee),
+          await SftRolesRegistry.roleExpirationDate(
+            RoleAssignment.grantor,
+            RoleAssignment.nonce,
+            RoleAssignment.role,
+            RoleAssignment.grantee
+          )
         ).to.be.equal(RoleAssignment.expirationDate)
       })
+
       it('should revert if role is not UNIQUE_ROLE', async () => {
         await expect(
           SftRolesRegistry.roleExpirationDate(
+            RoleAssignment.grantor,
             RoleAssignment.nonce,
             generateRoleId('NOT_UNIQUE_ROLE'),
             RoleAssignment.grantee,
           ),
         ).to.be.revertedWith('SftRolesRegistry: role not supported')
       })
+
       it('should revert if grantee is invalid', async () => {
         await expect(
-          SftRolesRegistry.roleExpirationDate(RoleAssignment.nonce, RoleAssignment.role, AddressZero),
+          SftRolesRegistry.roleExpirationDate(RoleAssignment.grantor, RoleAssignment.nonce, RoleAssignment.role, AddressZero),
         ).to.be.revertedWith('SftRolesRegistry: grantee mismatch')
       })
+
     })
   })
 
@@ -664,7 +670,7 @@ describe('SftRolesRegistrySingleRole', async () => {
     })
 
     it('should return true if IERCXXXX interface id', async () => {
-      expect(await SftRolesRegistry.supportsInterface('0x1ec9fef7')).to.be.true
+      expect(await SftRolesRegistry.supportsInterface('0xd38a803e')).to.be.true
     })
   })
 })

--- a/test/SftRolesRegistry/helpers.ts
+++ b/test/SftRolesRegistry/helpers.ts
@@ -53,7 +53,7 @@ export function buildRevokeRoleData(roleAssignment: RoleAssignment): RevokeRoleD
     role: roleAssignment.role,
     tokenAddress: roleAssignment.tokenAddress,
     tokenId: roleAssignment.tokenId,
-    revoker: roleAssignment.grantor,
+    grantor: roleAssignment.grantor,
     grantee: roleAssignment.grantee,
   }
 }

--- a/test/SftRolesRegistry/types.ts
+++ b/test/SftRolesRegistry/types.ts
@@ -16,6 +16,6 @@ export interface RevokeRoleData {
   role: string
   tokenAddress: string
   tokenId: number
-  revoker: string
+  grantor: string
   grantee: string
 }


### PR DESCRIPTION
Refactor the implementation of Single-Role SFT Roles Registry to use the updated interface and to implement mappings with both `role` and `nonce.`